### PR TITLE
Zeebe Insecure Authentication and Failjob and ThrowError

### DIFF
--- a/src/InsecureAuthentication.php
+++ b/src/InsecureAuthentication.php
@@ -1,0 +1,27 @@
+<?php
+namespace Camundity\PhpZeebe;
+
+class InsecureAuthentication {
+
+	private $clientId = '';
+	private $clientSecret = '';
+	private $token = null;
+	
+	public function __construct($clientId, $clientSecret) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+    }
+	
+	public function authenticate() {
+		$this->token = "";
+	}
+	
+	public function getToken() {
+		if (is_null($this->token)) {
+			$this->authenticate();
+		}
+		return $this->token;
+	}
+}
+
+?> 

--- a/src/ZeebeClient.php
+++ b/src/ZeebeClient.php
@@ -5,6 +5,7 @@ class ZeebeClient {
 
 	private $clusterId = null;
 	private $region = "bru-2";
+	private $zeebeUrl= ".zeebe.camunda.io:443"; 
 	private $authentication = null;
 	private $gatewayClient = null;
 	
@@ -16,6 +17,11 @@ class ZeebeClient {
 		$this->region = $region;
 		return $this;
 	}
+
+	public function zeebeUrl($zeebeUrl) {
+		$this->zeebeUrl = $zeebeUrl;
+		return $this;
+	}	
 	
 	public function saasAuth(string $clientId, string $clientSecret) {
 		$this->authentication = new SaaSAuthentication($clientId, $clientSecret);
@@ -26,12 +32,27 @@ class ZeebeClient {
 		$this->authentication = new SelfManagedAuthentication($clientId, $clientSecret, $zeebeAuthUrl);
         return $this;
 	}
+
+	public function insecureAuth(){
+		$this->authentication = new InsecureAuthentication();
+        return $this;
+	}	
 	
 	public function gatewayClient() {
 		if (is_null($this->gatewayClient)) {
 			$token = $this->authentication->getToken();
-			$this->gatewayClient = new \Camundity\PhpZeebe\Command\GatewayClient($this->clusterId.".".$this->region.".zeebe.camunda.io:443", [
-				'credentials' => \Grpc\ChannelCredentials::createSsl(),
+			echo "authentication: ".get_class($this->authentication)."\n"; 
+			$credentials= get_class($this->authentication) === "InsecureAuthentication" ? \Grpc\ChannelCredentials::createInsecure() : \Grpc\ChannelCredentials::createSsl(); 
+			if(!empty($this->region) && !is_null($this->region) && !strlen($this->region)===0)
+			$zeebeConnection=$this->region.$this->zeebeUrl; 
+			else
+			$zeebeConnection=$this->zeebeUrl; 
+			
+			if(!empty($this->clusterId)&& !is_null($this->clusterId) && !strlen($this->clusterId)===0)
+			$zeebeConnection=$ths->clusterId.".".$this->zeebeUrl; 
+			
+			$this->gatewayClient = new \Camundity\PhpZeebe\Command\GatewayClient($zeebeConnection, [
+				'credentials' =>$credentials,
 				'update_metadata' => function ($metaData) use ($token) {
 					$metaData['authorization'] = ['Bearer ' . $token];
 					return $metaData;
@@ -97,6 +118,33 @@ class ZeebeClient {
 
 		return $rsp;
 	}
+
+	public function failJob($jobKey, $retries, $errorMessage) {
+		
+		$request = new \Camundity\PhpZeebe\Command\FailJobRequest([
+			'jobKey' => $jobKey,
+			'retries' => $retries, 
+			'errorMessage' => $errorMessage
+		]);
+		
+		[$rsp, $status] = $this->gatewayClient->failJob($request)->wait();
+
+		return 	[$rsp, $status];
+	}
+	
+	public function throwError($jobKey, $errorCode, $errorMessage) {
+		
+		$request = new \Camundity\PhpZeebe\Command\ThrowErrorRequest([
+			'jobKey' => $jobKey,
+			'errorCode' => $errorCode, 
+			'errorMessage' => $errorMessage
+		]);
+		
+		[$rsp, $status] = $this->gatewayClient->ThrowError($request)->wait();
+
+		return 	[$rsp, $status];
+	}
+	
 	
 	public function publishMessage($messageName, $correlationKey, $variables) {
 		$request = new \Camundity\PhpZeebe\Command\PublishMessageRequest([


### PR DESCRIPTION
Trying to connect to self hosted zeebe with out cloack auth server support, I created and insecure authentication and did the required changes to zeebe client. 

Also the url is defined at the consturctor fo zeebeclient and added 2 additional functions to make the library more usable, a failjob and a throwerror... 

